### PR TITLE
Remove analyzer dependencies from NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <WarningsAsErrors/>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
-    <ItemGroup>
+    <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,8 +4,8 @@
         <WarningsAsErrors/>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
-    <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5" PrivateAssets="All" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"  PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/UnmanagedThreadUtils.sln
+++ b/UnmanagedThreadUtils.sln
@@ -12,11 +12,7 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -24,39 +20,15 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{365D5142-4088-4598-8724-0E7D0B549450}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{365D5142-4088-4598-8724-0E7D0B549450}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Debug|x64.Build.0 = Debug|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Debug|x86.Build.0 = Debug|Any CPU
 		{365D5142-4088-4598-8724-0E7D0B549450}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{365D5142-4088-4598-8724-0E7D0B549450}.Release|Any CPU.Build.0 = Release|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Release|x64.ActiveCfg = Release|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Release|x64.Build.0 = Release|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Release|x86.ActiveCfg = Release|Any CPU
-		{365D5142-4088-4598-8724-0E7D0B549450}.Release|x86.Build.0 = Release|Any CPU
 		{2DAD2005-9915-497E-8721-957BF409D7C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2DAD2005-9915-497E-8721-957BF409D7C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Debug|x64.Build.0 = Debug|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Debug|x86.Build.0 = Debug|Any CPU
 		{2DAD2005-9915-497E-8721-957BF409D7C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2DAD2005-9915-497E-8721-957BF409D7C8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Release|x64.ActiveCfg = Release|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Release|x64.Build.0 = Release|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Release|x86.ActiveCfg = Release|Any CPU
-		{2DAD2005-9915-497E-8721-957BF409D7C8}.Release|x86.Build.0 = Release|Any CPU
 		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Debug|x64.Build.0 = Debug|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Debug|x86.Build.0 = Debug|Any CPU
 		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Release|x64.ActiveCfg = Release|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Release|x64.Build.0 = Release|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Release|x86.ActiveCfg = Release|Any CPU
-		{7F100EC4-A38C-4B09-9735-D59C661CA368}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
+++ b/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  
-  <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\UnmanagedThreadUtils.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -24,5 +21,5 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
+++ b/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <CodeAnalysisRuleSet>..\..\UnmanagedThreadUtils.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -11,7 +14,7 @@
     <Description>Provides a way to subscribe to a Thread Exit event</Description>
     <PackageProjectUrl>https://github.com/ptupitsyn/UnmanagedThreadUtils</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ptupitsyn/UnmanagedThreadUtils.git</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Pavel Tupitsyn</Authors>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -20,6 +23,11 @@
 
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
+++ b/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+  <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\UnmanagedThreadUtils.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -25,9 +25,4 @@
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5" PrivateAssets="All" />
-  </ItemGroup>
-
 </Project>

--- a/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
+++ b/src/UnmanagedThreadUtils/UnmanagedThreadUtils.csproj
@@ -11,7 +11,7 @@
     <Description>Provides a way to subscribe to a Thread Exit event</Description>
     <PackageProjectUrl>https://github.com/ptupitsyn/UnmanagedThreadUtils</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ptupitsyn/UnmanagedThreadUtils.git</RepositoryUrl>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Pavel Tupitsyn</Authors>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Use `PrivateAssets="All"` to avoid extra dependencies